### PR TITLE
docs: add Deploy on Hostinger button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Deploy on Hostinger](https://assets.hostinger.com/vps/deploy.svg)](https://www.hostinger.com/web-apps-hosting)
+
 <p align="center">
    <a href="https://www.wrappixel.com/" target="_blank">
       <img src="https://adminmart.github.io/template_api/images/brand-logo/WrapPixel-Logo.svg" alt="materialpro-image" width="100px" height="100px">


### PR DESCRIPTION
This PR adds a "Deploy on Hostinger" button to the README for one-click hosting discovery.

- Button points to: https://www.hostinger.com/web-apps-hosting
- Only README was changed.